### PR TITLE
Prevent Stuck Loop

### DIFF
--- a/ESP32_FFT_VU/ESP32_FFT_VU.ino
+++ b/ESP32_FFT_VU/ESP32_FFT_VU.ino
@@ -116,7 +116,7 @@ void loop() {
     newTime = micros();
     vReal[i] = analogRead(AUDIO_IN_PIN); // A conversion takes about 9.7uS on an ESP32
     vImag[i] = 0;
-    while (micros() < (newTime + sampling_period_us)) { /* chill */ }
+    while ((micros() - newTime) < sampling_period_us) { /* chill */ }
   }
 
   // Compute FFT


### PR DESCRIPTION
Micros overflows every ~71.5 minutes. This can cause the newTime value to get stuck at a very high value while Micros rolls back to 0. When this happens the while condition in the sample loop is not met for a very long time.  Changing the while condition to check for the difference between the two unsigned longs prevents this possibility (a negative outcome is not possible as there is no sign).